### PR TITLE
stop_notify after connect

### DIFF
--- a/microbot/__init__.py
+++ b/microbot/__init__.py
@@ -233,6 +233,7 @@ class MicroBotApiClient:
                     await self._client.start_notify(
                         CHR2A89, self.notification_handler2
                     )
+                    await self._client.stop_notify(CHR2A89)
                 except Exception as e:
                     _LOGGER.error(e)
 


### PR DESCRIPTION
EPSHome bluetooth proxy client fails when start_notify is called more than once. Adding stop_notify call when finished with initial start_notify so that the second call can complete successfully. Second call already triggers stop_notify.